### PR TITLE
remove pico/stdlib.h include to fix pico build

### DIFF
--- a/src/platform/pico/sleep.c
+++ b/src/platform/pico/sleep.c
@@ -6,7 +6,6 @@
 
 #include "pico.h"
 
-#include "pico/stdlib.h"
 #include "sleep.h"
 
 #include "hardware/rtc.h"

--- a/src/platform/pico/stdlib.c
+++ b/src/platform/pico/stdlib.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "pico/stdlib.h"
 #include "hardware/pll.h"
 #include "hardware/clocks.h"
 #if LIB_PICO_STDIO_UART


### PR DESCRIPTION
Using the current versions of platformio libraries available today, I can't run `platformio run -e pico` without hitting

```
Compiling .pio/build/pico/src/platform/pico/stdlib.c.o
In file included from src/platform/pico/sleep.c:9:
/home/wes/.platformio/packages/framework-arduino-mbed/cores/arduino/mbed/targets/TARGET_RASPBERRYPI/TARGET_RP2040/pico-sdk/common/pico_stdlib/include/pico/stdlib.h:11:10: fatal error: pico/stdio.h: No such file or directory
   11 | #include "pico/stdio.h"
```

I found the fix in the fork from @nvts8a in https://github.com/nvts8a/libros/commits/58ede0950a810d9dc43a34748de46154c90a89f4